### PR TITLE
have energy sensor on PowerSwitch

### DIFF
--- a/src/Lupusec2Mqtt/Lupusec/PollingHostedService.cs
+++ b/src/Lupusec2Mqtt/Lupusec/PollingHostedService.cs
@@ -97,6 +97,7 @@ namespace Lupusec2Mqtt.Lupusec
                 _mqttService.Register(config.Value.Device.CommandTopic, state => SetState(state, config.Value.Device));
                 PublishDeviceToMqtt(config.Value.Device);
                 PublishDeviceToMqtt(config.Value.SwitchPowerSensor);
+                PublishDeviceToMqtt(config.Value.SwitchEnergySensor);
             }
         }
 
@@ -176,6 +177,7 @@ namespace Lupusec2Mqtt.Lupusec
             {
                 PublishStateToMqtt(device.Value.Device);
                 PublishStateToMqtt(device.Value.SwitchPowerSensor);
+                PublishStateToMqtt(device.Value.SwitchEnergySensor);
             }
         }
 

--- a/src/Lupusec2Mqtt/Mqtt/Homeassistant/ConversionService.cs
+++ b/src/Lupusec2Mqtt/Mqtt/Homeassistant/ConversionService.cs
@@ -44,18 +44,18 @@ namespace Lupusec2Mqtt.Mqtt.Homeassistant
             return list;
         }
 
-        public (ISettable Device, SwitchPowerSensor SwitchPowerSensor)? GetDevice(PowerSwitch powerSwitch)
+        public (ISettable Device, SwitchPowerSensor SwitchPowerSensor, SwitchEnergySensor SwitchEnergySensor)? GetDevice(PowerSwitch powerSwitch)
         {
             switch (powerSwitch.Type)
             {
                 case 24: // Wall switch
-                    return (Device: new Switch(_configuration, powerSwitch), SwitchPowerSensor: null);
+                    return (Device: new Switch(_configuration, powerSwitch), SwitchPowerSensor: null, SwitchEnergySensor: null);
                 case 48: // Power meter switch
-                    return (Device: new Switch(_configuration, powerSwitch), SwitchPowerSensor: new SwitchPowerSensor(_configuration, powerSwitch));
+                    return (Device: new Switch(_configuration, powerSwitch), SwitchPowerSensor: new SwitchPowerSensor(_configuration, powerSwitch), SwitchEnergySensor: new SwitchEnergySensor(_configuration, powerSwitch));
                 case 74: // Light switch
-                    return (Device: new Light(_configuration, powerSwitch), SwitchPowerSensor: null);
+                    return (Device: new Light(_configuration, powerSwitch), SwitchPowerSensor: null, SwitchEnergySensor: null);
                 case 57: // Smart Lock
-                    return (Device: new Lock(_configuration, powerSwitch), SwitchPowerSensor: null);
+                    return (Device: new Lock(_configuration, powerSwitch), SwitchPowerSensor: null, SwitchEnergySensor: null);
                 default:
                     LogIgnoredDevice(powerSwitch);
                     return null;
@@ -92,19 +92,20 @@ namespace Lupusec2Mqtt.Mqtt.Homeassistant
             return list;
         }
 
-        public (IStateProvider Device, IStateProvider SwitchPowerSensor)? GetStateProvider(PowerSwitch powerSwitch)
+        public (IStateProvider Device, IStateProvider SwitchPowerSensor, IStateProvider SwitchEnergySensor)? GetStateProvider(PowerSwitch powerSwitch)
         {
             switch (powerSwitch.Type)
             {
                 case 24: // Wall switch
-                    return (Device: new Switch(_configuration, powerSwitch), SwitchPowerSensor: null);
+                    return (Device: new Switch(_configuration, powerSwitch), SwitchPowerSensor: null, SwitchEnergySensor: null);
                 case 48: // Power meter switch
                     return (Device: new Switch(_configuration, powerSwitch),
-                            SwitchPowerSensor: new SwitchPowerSensor(_configuration, powerSwitch));
+                            SwitchPowerSensor: new SwitchPowerSensor(_configuration, powerSwitch), 
+                            SwitchEnergySensor: new SwitchEnergySensor(_configuration, powerSwitch));
                 case 74: // Light switch
-                    return (Device: new Light(_configuration, powerSwitch), SwitchPowerSensor: null);
-                case 57: // Smart Lock
-                    return (Device: new Lock(_configuration, powerSwitch), SwitchPowerSensor: null);
+                    return (Device: new Light(_configuration, powerSwitch), SwitchPowerSensor: null, SwitchEnergySensor: null);
+                case 57: // Smart Lock                                                            
+                    return (Device: new Lock(_configuration, powerSwitch), SwitchPowerSensor: null, SwitchEnergySensor: null);
                 default:
                     LogIgnoredDevice(powerSwitch);
                     return null;

--- a/src/Lupusec2Mqtt/Mqtt/Homeassistant/Devices/HumiditySensor.cs
+++ b/src/Lupusec2Mqtt/Mqtt/Homeassistant/Devices/HumiditySensor.cs
@@ -25,6 +25,9 @@ namespace Lupusec2Mqtt.Mqtt.Homeassistant.Devices
         [JsonProperty("unit_of_measurement")]
         public string UnitOfMeasurement => "%";
 
+        [JsonProperty("state_class")]
+        public string StateClass => "measurement";
+
         protected override string _component => "sensor";
 
         private string GetState()

--- a/src/Lupusec2Mqtt/Mqtt/Homeassistant/Devices/SwitchEnergySensor.cs
+++ b/src/Lupusec2Mqtt/Mqtt/Homeassistant/Devices/SwitchEnergySensor.cs
@@ -9,7 +9,7 @@ using System.Threading.Tasks;
 
 namespace Lupusec2Mqtt.Mqtt.Homeassistant.Devices
 {
-    public class SwitchPowerSensor : Device, IDevice, IStateProvider
+    public class SwitchEnergySensor : Device, IDevice, IStateProvider
     {
         protected readonly PowerSwitch _powerSwitch;
 
@@ -20,10 +20,10 @@ namespace Lupusec2Mqtt.Mqtt.Homeassistant.Devices
         public string StateTopic => EscapeTopic($"homeassistant/{_component}/lupusec/{UniqueId}/state");
 
         [JsonProperty("unit_of_measurement")]
-        public string UnitOfMeasurement => "W";
+        public string UnitOfMeasurement => "kWh";
 
         [JsonProperty("state_class")]
-        public string StateClass => "measurement";
+        public string StateClass => "total";
 
         [JsonIgnore]
         public string State => GetState();
@@ -33,25 +33,25 @@ namespace Lupusec2Mqtt.Mqtt.Homeassistant.Devices
 
         private string GetState()
         {
-            var match = Regex.Match(_powerSwitch.Status, @"{WEB_MSG_PSM_POWER}\s*(?'power'\d+\.?\d*)");
+            var match = Regex.Match(_powerSwitch.Status, @"{WEB_MSG_POWER_METER_ENERGY}\s*(?'energy'\d+\.?\d*)");
 
-            if (match.Success) { return match.Groups["power"].Value; }
+            if (match.Success) { return match.Groups["energy"].Value; }
             return "0";
         }
    
-        public SwitchPowerSensor(IConfiguration configuration, PowerSwitch powerSwitch)
+        public SwitchEnergySensor(IConfiguration configuration, PowerSwitch powerSwitch)
        : base(configuration)
         {
             _powerSwitch = powerSwitch;
 
-            UniqueId = $"{_powerSwitch.Id}_power";
-            Name = GetValue(nameof(Name), $"{_powerSwitch.Name} - Power");
+            UniqueId = $"{_powerSwitch.Id}_energy";
+            Name = GetValue(nameof(Name), $"{_powerSwitch.Name} - Energy");
             DeviceClass = GetValue(nameof(DeviceClass), GetDeviceClassDefaultValue());
         }
 
         private static string GetDeviceClassDefaultValue()
         {
-            return "power";
+            return "energy";
         }
     }
 }

--- a/src/Lupusec2Mqtt/Mqtt/Homeassistant/Devices/TemperatureSensor.cs
+++ b/src/Lupusec2Mqtt/Mqtt/Homeassistant/Devices/TemperatureSensor.cs
@@ -25,6 +25,9 @@ namespace Lupusec2Mqtt.Mqtt.Homeassistant.Devices
         [JsonProperty("unit_of_measurement")]
         public string UnitOfMeasurement => "\x00B0C";
 
+        [JsonProperty("state_class")]
+        public string StateClass => "measurement";
+
         protected override string _component => "sensor";
 
         private string GetState()


### PR DESCRIPTION
The Power Switch also carries a energy meter. Even though energy aggregation could be done on home assistant itself, I'd rather rely on the internal aggregation of the meter itself, as it is more reliable. 

In other cases, as the Power Switch carries the data, I think it is useful to have it available.

I feel the return value of ConversionService.GetDevice and ConversionService.GetStateProvider is a little bit cumbersome currently, as I now have added the new  SwitchEnergySensor as an additional return value, which is null for most devices. Maybe should rather return a list of thingies of the same interface.

But that would be another type of change...