### PR TITLE
fix: mqtt messages are now retained

### DIFF
--- a/src/Lupusec2Mqtt/Mqtt/MqttService.cs
+++ b/src/Lupusec2Mqtt/Mqtt/MqttService.cs
@@ -2,6 +2,7 @@
 using MQTTnet;
 using MQTTnet.Client;
 using MQTTnet.Extensions.ManagedClient;
+using MQTTnet.Protocol;
 using System;
 using System.Collections.Generic;
 using System.Text;
@@ -60,7 +61,14 @@ namespace Lupusec2Mqtt.Mqtt
 
         public async Task PublishAsync(string topic, string payload)
         {
-            await _managedMqttClient.EnqueueAsync(topic, payload);
+            var message = new MqttApplicationMessageBuilder()
+                .WithTopic(topic)
+                .WithPayload(payload)
+                .WithQualityOfServiceLevel(MqttQualityOfServiceLevel.AtLeastOnce)
+                .WithRetainFlag(true)
+                .Build();
+
+            await _managedMqttClient.EnqueueAsync(message);
         }
 
         public async Task StopAsync()


### PR DESCRIPTION
As the messages were not retained, after a HA restart the entities were not available until a state change