### PR TITLE
Fix smoke detector state detection to use AlarmStatus field

### DIFF
--- a/src/Lupusec2Mqtt/Mqtt/Homeassistant/Devices/SmokeDetector.cs
+++ b/src/Lupusec2Mqtt/Mqtt/Homeassistant/Devices/SmokeDetector.cs
@@ -26,7 +26,9 @@ namespace Lupusec2Mqtt.Mqtt.Homeassistant.Devices
         public Task<string> GetState(ILogger logger, ILupusecService lupusecService)
         {
             var sensor = lupusecService.SensorList.Sensors.Single(s => s.SensorId == GetStaticValue<string>("unique_id"));
-            var result = sensor.StatusEx == 1 || sensor.Status.Equals("DOORBELL", System.StringComparison.OrdinalIgnoreCase) ? "ON" : "OFF"; 
+
+            // Check AlarmStatus field - any non-empty value indicates smoke/fire alarm is triggered
+            var result = !string.IsNullOrEmpty(sensor.AlarmStatus) ? "ON" : "OFF";
 
             return Task.FromResult(result);
         }


### PR DESCRIPTION
Changed from checking StatusEx/DOORBELL to checking the AlarmStatus field, which is the correct field for smoke alarm detection based on the Lupusec API specification used by other integrations (ioBroker.lupusec).

This matches the pattern already used in MoistureDetector where AlarmStatus is checked for alarm conditions.